### PR TITLE
fix: update i18n property for asl and lsq fields to not duplicate

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -26,8 +26,8 @@ collections:
       - {label: Excerpt, name: excerpt, widget: string, required: false, i18n: true}
       - {label: YouTube Video, name: youtube, widget: string, type: url, required: false, i18n: true}
       - {label: YouTube Video Transcript Link, name: transcript, widget: string, type: url, required: false, i18n: true}
-      - {label: ASL Video, name: asl, widget: string, type: url, required: false, i18n: duplicate}
-      - {label: LSQ Video, name: lsq, widget: string, type: url, required: false, i18n: duplicate}
+      - {label: ASL Video, name: asl, widget: string, type: url, required: false, i18n: true}
+      - {label: LSQ Video, name: lsq, widget: string, type: url, required: false, i18n: true}
       - {label: Introduction, name: intro, widget: markdown, i18n: true, required: false}
       - {label: Body, name: body, widget: markdown, i18n: true}
   - label: Submissions


### PR DESCRIPTION
## Description

<!-- A description of the pull request -->

ASL and LSQ fields of the Pages collection shouldn't be duplicated, as English site doesn't have to display LSQ video and vice versa.