### PR TITLE
fix: style issues (resolves #46 and #47)

### DIFF
--- a/src/_includes/partials/components/submission.njk
+++ b/src/_includes/partials/components/submission.njk
@@ -52,7 +52,7 @@
         <li class="youtube">{% include 'svg/youtube.svg' %} <a aria-describedby="{{ submission.data.id }}" href="{{ submission.data.youtube.url }}">
             {% localizedFormat 'youtube', submission.data.youtube.lang, lang %}</a>
             {% if submission.data.youtube.signLanguageUrl -%}
-                | <a aria-describedby="{{ submission.data.id }}" href="{{ submission.data.youtube.signLanguageUrl }}"> {{ 'interpretation' | i18n }} </a>
+                / <a aria-describedby="{{ submission.data.id }}" href="{{ submission.data.youtube.signLanguageUrl }}"> {{ 'interpretation' | i18n }} </a>
             {%- endif %}
         {% endif %}
         {% if submission.data.audio %}

--- a/src/assets/styles/app.css
+++ b/src/assets/styles/app.css
@@ -481,6 +481,7 @@ h3::after,
 }
 
 .linked-video {
+    color: inherit;
     display: block;
     max-width: 55.625rem;
     position: relative;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Resolves #46 and #47

## Steps to test

1. Check the submissions with both english and ASL videos and links for them are separated by `/`
2. Check that the introduction video doesn't have blue outline when focused, and the "Play video" text stays black