### PR TITLE
fix: update how asl and lsq filters are applied to submissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,6 @@
   "lint-staged": {
     "*.css": "stylelint --fix",
     "*.{js,cjs,json,jsonc}": "biome check --write --no-errors-on-unmatched",
-    "*.md": [
-      "markdownlint-cli2 --fix"
-    ]
+    "*.md": ["markdownlint-cli2 --fix"]
   }
 }

--- a/src/_includes/partials/components/submission.njk
+++ b/src/_includes/partials/components/submission.njk
@@ -10,7 +10,10 @@
     "
     data-filter-language="
     {%- if submission.data.youtube.interpretation -%}
-        {{ 'asl' if submission.data.youtube.lang === 'en' else 'lsq' }},
+        {{ 'asl' if submission.data.youtube.lang === 'en' and submission.data.youtube.signLanguageUrl }},
+    {%- endif -%}
+    {%- if submission.data.youtube.interpretation -%}
+        {{ 'lsq' if submission.data.youtube.lang === 'fr' and submission.data.youtube.signLanguageUrl }},
     {%- endif -%}
     {%- if submission.data.youtube.lang === 'en' or submission.data.text.en or submission.data.transcript.en or submission.data.slides.en or submission.data.audio.lang === 'en' or submission.data.pdf.en -%}
         en,

--- a/src/_includes/partials/components/submission.njk
+++ b/src/_includes/partials/components/submission.njk
@@ -9,11 +9,8 @@
     {%- endfor -%}
     "
     data-filter-language="
-    {%- if submission.data.youtube.interpretation -%}
-        {{ 'asl' if submission.data.youtube.lang === 'en' and submission.data.youtube.signLanguageUrl }},
-    {%- endif -%}
-    {%- if submission.data.youtube.interpretation -%}
-        {{ 'lsq' if submission.data.youtube.lang === 'fr' and submission.data.youtube.signLanguageUrl }},
+    {%- if submission.data.youtube.signLanguageUrl -%}
+        {{ 'asl' if submission.data.youtube.lang === 'en' else 'lsq' }},
     {%- endif -%}
     {%- if submission.data.youtube.lang === 'en' or submission.data.text.en or submission.data.transcript.en or submission.data.slides.en or submission.data.audio.lang === 'en' or submission.data.pdf.en -%}
         en,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Sign language filters were not working as expected because previously we were expecting to get separate submissions for ASL and LSQ videos. Add additional condition to submissions to check if asl or lsq video is linked.

## Steps to test

1. Go to the submissions page and check language filter to ASL
2. See only submissions with ASL videos are showing up from the filtering
